### PR TITLE
.live() method is deprecated since jQuery v1.7

### DIFF
--- a/public/js/plugin-name-public.js
+++ b/public/js/plugin-name-public.js
@@ -13,9 +13,9 @@
 	    var textInputs = $('[contenteditable]');
 	    textInputs.each(function() {
 	    	var contents =$(this).html();
-	    	$(this).live('focus', function() {
+	    	$(this).on('focus', function() {
 	    		// console.log($(this).html());
-	    	}).live('blur', function() {
+	    	}).on('blur', function() {
 	    		// console.log($(this).html());
 	    		if (contents!=$(this).html()){
 	    	    $(this).addClass('textChanged');
@@ -27,7 +27,7 @@
 	    });
     });
 
-	$('#wp-admin-bar-edit-live').live('click',function() {
+	$('#wp-admin-bar-edit-live').on('click',function() {
 		var editableText = $('[contenteditable].textChanged');
 		var textString = [];
 		editableText.each(function() {


### PR DESCRIPTION
.live() method is deprecated since jQuery v1.7; replace it with .on() method;