### PR TITLE
Added composer.json file.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "horiondigital/advanced-custom-fields-front-end-editor",
+    "description": "Add on for advanced custom fields plugin which allow to edit text fields, text areas and wysiwyg fields via front end magically",
+    "keywords": ["wordpress", "plugin", "acf", "advanced-custom-fields"],
+    "homepage": "https://github.com/HorionDigital/advanced-custom-fields-front-end-editor",
+    "license": "GPL-2.0+",
+    "authors": [
+        {
+              "name": "Audrius Rackauskas",
+              "homepage": "http://www.horiondigital.com"
+        }
+    ],
+    "support"    : {
+            "issues": "https://github.com/HorionDigital/advanced-custom-fields-front-end-editor/issues",
+            "source": "https://github.com/HorionDigital/advanced-custom-fields-front-end-editor"
+    },
+    "type": "wordpress-plugin",
+    "require": {
+        "composer/installers": "~1.0"
+    }
+}


### PR DESCRIPTION
This would help people who use composer.json to manage their WordPress plugins to use your plugin.

After this is published it would be helpful if you set added it to [Packagist](https://packagist.org/). I would be happy to help you with that or help test.

Also - it would be great if you could publish a [release](https://github.com/HorionDigital/advanced-custom-fields-front-end-editor/releases) now that you are at 2.0.

Thanks!