### PR TITLE
Allow for deleted area to regain refocus

### DIFF
--- a/public/css/acf-front-end-editor-public.css
+++ b/public/css/acf-front-end-editor-public.css
@@ -15,3 +15,8 @@
   font-size: 16px;
   z-index: 999;
 }
+
+[contenteditable]:empty {
+    display: block;
+    height: 1em;
+}


### PR DESCRIPTION
**Senario**

1. I edit a editable block and delete all the containing text
2. Before I save I decide to edit another area
3. After editing the other area I realize I want to edit the previous area again. However because the editable area no longer has any content it's impossible to gain focus / click on the area since the editable block has a height of zero.

By adding the above css we'll be able to avoid this small nuisance and edit the empty area.  This would also allow us to change the default functionality of the plugin since we currently have to have content added in the backend to a field  before it can be edited in the frontend.